### PR TITLE
Make `fetch` configurable via `options.client`

### DIFF
--- a/fetch-suspense.d.ts
+++ b/fetch-suspense.d.ts
@@ -1,5 +1,6 @@
 declare const deepEqual: any;
 interface FetchCache {
+    client: (input: RequestInfo, init?: RequestInit | undefined) => Promise<any>;
     fetch?: Promise<void>;
     error?: any;
     init: RequestInit | undefined;
@@ -7,4 +8,8 @@ interface FetchCache {
     response?: any;
 }
 declare const fetchCaches: FetchCache[];
-declare const useFetch: (input: RequestInfo, init?: RequestInit | undefined, lifespan?: number) => any;
+interface UseFetchConfig {
+    client?: (input: RequestInfo, init?: RequestInit | undefined) => Promise<any>;
+    lifespan?: number;
+}
+declare const useFetch: (input: RequestInfo, init?: RequestInit | undefined, config?: number | UseFetchConfig | undefined) => any;


### PR DESCRIPTION
Hi, thanks for the great lib! I'm new to TS so please forgive my newbie typings.

I personally use the composable **fetch** lib called [http-client](https://www.npmjs.com/package/http-client). This PR allows me to use the `fetch` it generated instead of defaulting to the global one.

```js
import useFetch from "fetch-suspense";
import { createFetch } from "http-client";

const client = createFetch(/* … */);

useFetch(input, init, {
  client,
});
```