### PR TITLE
Added default exports to fetch-suspense.d.ts, fetch-suspense.ts

### DIFF
--- a/fetch-suspense.d.ts
+++ b/fetch-suspense.d.ts
@@ -8,3 +8,6 @@ interface FetchCache {
 }
 declare const fetchCaches: FetchCache[];
 declare const useFetch: (input: RequestInfo, init?: RequestInit | undefined, lifespan?: number) => any;
+
+export { useFetch };
+export default useFetch;

--- a/fetch-suspense.d.ts
+++ b/fetch-suspense.d.ts
@@ -9,5 +9,4 @@ interface FetchCache {
 declare const fetchCaches: FetchCache[];
 declare const useFetch: (input: RequestInfo, init?: RequestInit | undefined, lifespan?: number) => any;
 
-export { useFetch };
 export default useFetch;

--- a/fetch-suspense.ts
+++ b/fetch-suspense.ts
@@ -82,4 +82,4 @@ const useFetch = (input: RequestInfo, init?: RequestInit | undefined, lifespan: 
 
 module.exports = useFetch;
 module.exports.default = useFetch;
-module.exports.useFetch= useFetch;
+module.exports.useFetch = useFetch;

--- a/fetch-suspense.ts
+++ b/fetch-suspense.ts
@@ -82,4 +82,3 @@ const useFetch = (input: RequestInfo, init?: RequestInit | undefined, lifespan: 
 
 module.exports = useFetch;
 module.exports.default = useFetch;
-module.exports.useFetch = useFetch;

--- a/fetch-suspense.ts
+++ b/fetch-suspense.ts
@@ -81,3 +81,5 @@ const useFetch = (input: RequestInfo, init?: RequestInit | undefined, lifespan: 
 };
 
 module.exports = useFetch;
+module.exports.default = useFetch;
+module.exports.useFetch= useFetch;


### PR DESCRIPTION
Fixes #10. Fixes #11.

This includes ~both~ a `default` export ~and an export named `useFetch`. I'm happy to remove one if you'd rather just have one style.~

Edit: per https://github.com/CharlesStover/fetch-suspense/issues/11#issuecomment-482221729, now it's just the `default`. 👍 