### PR TITLE
fix error on window undefined (support SSR)

### DIFF
--- a/src/fetch-suspense.ts
+++ b/src/fetch-suspense.ts
@@ -193,10 +193,25 @@ const createUseFetch: CreateUseFetch = (
   return useFetch;
 };
 
+// Ensure `window` and `window.fetch` is present.
+const missing = typeof window === 'undefined'
+  ? 'window'
+  : window.fetch
+    ? false
+    : 'window.fetch';
+
+// If `window.fetch` is missing, throw an error when
+// called with a message to use `createUseFetch` instead.
+const defaultVal = missing
+  ? () => {
+    throw new Error('Cannot find `' + missing + '`. Use `createUseFetch` and provide `fetch` function.');
+  }
+  : createUseFetch(window.fetch);
+
 const _export: Export = Object.assign(
-  createUseFetch(window.fetch), {
+  defaultVal, {
   createUseFetch,
-  default: createUseFetch(window.fetch)
+  default: defaultVal
 });
 
 export = _export;

--- a/tests/use-fetch.test.ts
+++ b/tests/use-fetch.test.ts
@@ -1,18 +1,46 @@
 import { expect } from 'chai';
-import useFetch from '../fetch-suspense';
-import CommonJS = require('../fetch-suspense');
-
-
 
 describe('useFetch', (): void => {
 
-  it('should be a function with 3 parameters via CommonJS', (): void => {
-    expect(CommonJS).to.be.a('function');
-    expect(CommonJS.length).to.equal(3);
+  it('should be a function that throws an error when window is not available', (): void => {
+    // Remove the window object on global.
+    (global as any).window = undefined;
+    delete require.cache[require.resolve('../fetch-suspense')];
+    const useFetch = require('../fetch-suspense');
+    expect(useFetch).to.be.a('function');
+    expect(useFetch.length).to.equal(0);
+    expect(useFetch.default).to.eq(useFetch);
+    expect(() => useFetch()).to.throw('Cannot find `window`');
   });
 
-  it('should be a function with 3 parameters via ES6', (): void => {
+  it('should be a function that throws an error when window.fetch is not available', (): void => {
+    // Set window object on global but without fetch.
+    (global as any).window = {};
+    delete require.cache[require.resolve('../fetch-suspense')];
+    const useFetch = require('../fetch-suspense');
+    expect(useFetch).to.be.a('function');
+    expect(useFetch.length).to.equal(0);
+    expect(useFetch.default).to.eq(useFetch);
+    expect(() => useFetch()).to.throw('Cannot find `window.fetch`');
+  });
+
+  it('should be a function with 3 parameters via CommonJS when window.fetch is available', (): void => {
+    // Set window object on global with a mock fetch function.
+    (global as any).window = { fetch: () => 'test-val' };
+    delete require.cache[require.resolve('../fetch-suspense')];
+    const useFetch = require('../fetch-suspense');
     expect(useFetch).to.be.a('function');
     expect(useFetch.length).to.equal(3);
+    expect(useFetch.default).to.eq(useFetch);
+  });
+
+  it('should be a function with 3 parameters via ES6 when window.fetch is available', async (): Promise<void> => {
+    // Set window object on global with a mock fetch function.
+    (global as any).window = { fetch: () => 'test-val' };
+    delete require.cache[require.resolve('../fetch-suspense')];
+    const useFetch = await import('../fetch-suspense');
+    expect(useFetch).to.be.a('function');
+    expect((useFetch as any).length).to.equal(3);
+    expect(useFetch.default).to.eq(useFetch);
   });
 });


### PR DESCRIPTION
Firstly, thank you for this awesome module!

There is an issue that I'm running into. Currently, if `window` is undefined, an unrecoverable error is thrown when this module is run, preventing it from being used in SSR use cases where `window` is not available.

This PR checks for the presence of `window` and `window.fetch` _before_ creating the default `useFetch` function. If `window` is not defined, the default `useFetch` function will throw an error with a detailed message with a message suggesting to leverage `createUseFetch` instead.